### PR TITLE
Don't call puts on system call

### DIFF
--- a/deckcycle.rb
+++ b/deckcycle.rb
@@ -40,7 +40,7 @@ mandatory = [:name, :username, :password]
 missing = mandatory.select { |param| options[param].nil? }
 unless missing.empty?
   puts "Missing options: #{missing.join(', ')}"
-  puts system "ruby #{__FILE__} -h"
+  system "ruby #{__FILE__} -h"
   exit
 end
 


### PR DESCRIPTION
Puts was returning the exit status of 'exit' in OptionParser

Fixes jakewras/mtg-deckcycle#3
